### PR TITLE
Refactor/media queries #33

### DIFF
--- a/src/css/bello-board-home/layout.css
+++ b/src/css/bello-board-home/layout.css
@@ -14,15 +14,27 @@
     display: inline;
     padding: 5px;
     margin-right: 10px; }
+    @media screen and (max-width: 650px) {
+      .navbar .board-btn {
+        position: static; } }
     .navbar .board-btn * {
       display: inline; }
     .navbar .board-btn .board-text {
       font-weight: bold; }
+      @media screen and (max-width: 650px) {
+        .navbar .board-btn .board-text {
+          display: none; } }
   .navbar .search-wrapper {
     position: relative;
     margin-right: 10px; }
+    @media screen and (max-width: 650px) {
+      .navbar .search-wrapper {
+        margin-left: 30px; } }
     .navbar .search-wrapper .search-box {
       width: 200px; }
+      @media screen and (max-width: 650px) {
+        .navbar .search-wrapper .search-box {
+          display: none; } }
       .navbar .search-wrapper .search-box:focus {
         width: 300px;
         background: #ececec; }
@@ -33,12 +45,21 @@
       top: 0;
       bottom: 0;
       right: 0; }
+      @media screen and (max-width: 650px) {
+        .navbar .search-wrapper .search-btn {
+          display: static; } }
   .navbar .logo {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translateY(-40%);
     z-index: 1; }
+    @media screen and (max-width: 650px) {
+      .navbar .logo {
+        display: block;
+        position: static;
+        transform: translateY(0);
+        margin-left: auto; } }
   .navbar .btn-right-group-container {
     display: inline-flex;
     margin-left: auto; }
@@ -46,6 +67,9 @@
       margin-right: 10px; }
     .navbar .btn-right-group-container > *:last-child {
       margin-right: 0; }
+  @media screen and (max-width: 650px) {
+    .navbar .info-btn {
+      display: none; } }
 
 main .boards-container {
   display: flex;
@@ -64,11 +88,16 @@ main .boards__grid {
   grid-row-gap: 16px;
   justify-content: start;
   align-items: center; }
+  @media screen and (max-width: 650px) {
+    main .boards__grid {
+      grid-template-columns: 1fr; } }
 
 main .board-tile {
   position: relative; }
-  main .board-tile-primary:not(:hover) .board-tile__star--appear {
-    display: none; }
+  main .board-tile-primary {
+    width: 100%; }
+    main .board-tile-primary:not(:hover) .board-tile__star--appear {
+      display: none; }
   main .board-tile__star {
     position: relative;
     z-index: 2; }
@@ -90,28 +119,3 @@ main .board-tile {
     bottom: 0;
     left: 0;
     z-index: 1; }
-
-@media only screen and (max-width: 650px) {
-  .navbar .board-btn {
-    position: static; }
-    .navbar .board-btn .board-text {
-      display: none; }
-  .navbar .search-wrapper {
-    margin-left: 30px; }
-    .navbar .search-wrapper .search-box {
-      display: none; }
-  .navbar .search-btn {
-    position: static; }
-  .navbar .logo {
-    display: block;
-    position: static;
-    transform: translateY(0);
-    margin-left: auto; }
-  .navbar .btn-right-group-container {
-    margin-left: auto; }
-    .navbar .btn-right-group-container .info-btn {
-      display: none; }
-  main .boards__grid {
-    grid-template-columns: 1fr; }
-  main .board-tile-primary {
-    width: 100%; } }

--- a/src/scss/bello-board-home/base.scss
+++ b/src/scss/bello-board-home/base.scss
@@ -1,0 +1,1 @@
+@import 'global/_media-queries';

--- a/src/scss/bello-board-home/components.scss
+++ b/src/scss/bello-board-home/components.scss
@@ -10,6 +10,7 @@
 //-----------
 //==================
 
+@import 'base';
 //General Colors
 $white-primary-color: #ececec;
 $blue-primary-color: #0084ff;

--- a/src/scss/bello-board-home/global/_media-queries.scss
+++ b/src/scss/bello-board-home/global/_media-queries.scss
@@ -1,0 +1,5 @@
+@mixin device-sm-and-md {
+    @media screen and (max-width: 650px) {
+        @content;
+    }
+}

--- a/src/scss/bello-board-home/layout.scss
+++ b/src/scss/bello-board-home/layout.scss
@@ -1,6 +1,7 @@
 $blue-navbar: #026aa7;
 $white-primary-color: #ececec;
 $sm-margin: 10px;
+@import 'base';
 .navbar {
     display: flex;
     flex-direction: row;
@@ -17,19 +18,31 @@ $sm-margin: 10px;
         display: inline;
         padding: 5px;
         margin-right: $sm-margin;
+        @include device-sm-and-md {
+            position: static;
+        }
         * {
             display: inline;
         }
         .board-text {
             font-weight: bold;
+            @include device-sm-and-md {
+                display: none;
+            }
         }
     }
     /*Search Bar*/
     .search-wrapper {
         position: relative;
         margin-right: $sm-margin;
+        @include device-sm-and-md {
+            margin-left: 30px;
+        }
         .search-box {
             width: 200px;
+            @include device-sm-and-md {
+                display: none;
+            }
             &:focus {
                 width: 300px;
                 background: $white-primary-color;
@@ -43,6 +56,9 @@ $sm-margin: 10px;
             top: 0;
             bottom: 0;
             right: 0;
+            @include device-sm-and-md {
+                display: static;
+            }
         }
     } //Navbar Logo
     .logo {
@@ -51,6 +67,12 @@ $sm-margin: 10px;
         left: 50%;
         transform: translateY(-40%);
         z-index: 1;
+        @include device-sm-and-md {
+            display: block;
+            position: static;
+            transform: translateY(0);
+            margin-left: auto;
+        }
     } //Right Group Buttons
     .btn-right-group-container {
         display: inline-flex;
@@ -60,6 +82,11 @@ $sm-margin: 10px;
         }
         &>*:last-child {
             margin-right: 0;
+        }
+    }
+    .info-btn {
+        @include device-sm-and-md {
+            display: none;
         }
     }
 }
@@ -87,11 +114,15 @@ main {
             grid-row-gap: 16px;
             justify-content: start;
             align-items: center;
+            @include device-sm-and-md {
+                grid-template-columns: 1fr;
+            }
         }
     }
     .board-tile {
         position: relative;
         &-primary {
+            width: 100%;
             &:not(:hover) {
                 .board-tile__star--appear {
                     display: none;
@@ -122,50 +153,6 @@ main {
             bottom: 0;
             left: 0;
             z-index: 1;
-        }
-    }
-}
-
-@media only screen and (max-width: 650px) {
-    .navbar {
-        .board-btn {
-            position: static;
-            .board-text {
-                display: none;
-            }
-        }
-        .search-wrapper {
-            margin-left: 30px;
-            .search-box {
-                display: none;
-            }
-        }
-        .search-btn {
-            position: static;
-        }
-        .logo {
-            display: block;
-            position: static;
-            transform: translateY(0);
-            margin-left: auto;
-        }
-        .btn-right-group-container {
-            margin-left: auto;
-            .info-btn {
-                display: none;
-            }
-        }
-    }
-    main {
-        .boards {
-            &__grid {
-                grid-template-columns: 1fr;
-            }
-        }
-        .board-tile {
-            &-primary {
-                width: 100%;
-            }
         }
     }
 }


### PR DESCRIPTION
Added directories to keep variables and media queries organized plus a modules folder for future re-use for multiple re-uses of the navbar and footer. Media queries were simplified to avoid specificity problem and to keep all styling of 1 class in the same screen view.